### PR TITLE
Add Foundry tests and CI for contracts

### DIFF
--- a/.github/workflows/forge-tests.yml
+++ b/.github/workflows/forge-tests.yml
@@ -1,0 +1,26 @@
+name: Forge Tests
+
+on:
+  pull_request:
+  push:
+    branches: [ main, master ]
+
+jobs:
+  test-contracts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+
+      - name: Run forge tests (contracts)
+        working-directory: base-oss-app/contracts
+        run: |
+          forge --version
+          forge test --match-path 'test/*' -vvv

--- a/base-oss-app/contracts/test/ApplicationManager.t.sol
+++ b/base-oss-app/contracts/test/ApplicationManager.t.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import {ApplicationManager} from "../src/ApplicationManager.sol";
+import {RepoRegistry} from "../src/RepoRegistry.sol";
+import {ProfileRegistry} from "../src/ProfileRegistry.sol";
+
+contract ApplicationManagerTest is Test {
+    RepoRegistry rr;
+    ProfileRegistry pr;
+    ApplicationManager am;
+
+    address maint = address(0xA11CE);
+    address contrib = address(0xB0B);
+
+    function setUp() public {
+        rr = new RepoRegistry();
+        pr = new ProfileRegistry();
+        am = new ApplicationManager(address(rr), address(pr));
+        // Grant AM role in RR
+        rr.grantRole(rr.APPLICATION_MANAGER_ROLE(), address(am));
+
+        // Create contributor profile
+        string[] memory tech = new string[](1);
+        tech[0] = "Solidity";
+        string[] memory topics = new string[](0);
+        vm.prank(contrib);
+        pr.createProfile("b0b", "", tech, topics, ProfileRegistry.ExperienceLevel.Beginner, ProfileRegistry.Role.Contributor);
+
+        // Add repo
+        string[] memory rtech = new string[](1);
+        rtech[0] = "Solidity";
+        string[] memory rtopics = new string[](0);
+        vm.prank(maint);
+        uint256 repoId = rr.addRepo("o/r", "r", "d", rtech, rtopics, "", 0);
+
+        // Add issue
+        string[] memory labels = new string[](0);
+        vm.prank(maint);
+        rr.addIssue(repoId, "o/r#1", "task", "d", labels, RepoRegistry.Difficulty.Beginner, 1, 0);
+    }
+
+    function testApplyAcceptAssign() public {
+        // contrib applies
+        vm.prank(contrib);
+        uint256 appId = am.applyToIssue(1, "hello", 100);
+        assertEq(appId, 1);
+
+        // maint accepts (should assign in repo)
+        vm.prank(maint);
+        am.acceptApplication(appId);
+        RepoRegistry.Issue memory iss = rr.getIssue(1);
+        assertEq(iss.assignedContributor, contrib);
+        assertEq(uint(iss.status), uint(RepoRegistry.Status.Assigned));
+    }
+}

--- a/base-oss-app/contracts/test/ProfileRegistry.t.sol
+++ b/base-oss-app/contracts/test/ProfileRegistry.t.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import {ProfileRegistry} from "../src/ProfileRegistry.sol";
+
+contract ProfileRegistryTest is Test {
+    ProfileRegistry pr;
+    address user = address(0xBEEF);
+
+    function setUp() public {
+        pr = new ProfileRegistry();
+    }
+
+    function testCreateAndUpdateProfile() public {
+        string[] memory tech = new string[](2);
+        tech[0] = "Solidity";
+        tech[1] = "TypeScript";
+        string[] memory topics = new string[](1);
+        topics[0] = "DeFi";
+
+        vm.prank(user);
+        pr.createProfile(
+            "user123",
+            "I build things",
+            tech,
+            topics,
+            ProfileRegistry.ExperienceLevel.Intermediate,
+            ProfileRegistry.Role.Contributor
+        );
+
+        ProfileRegistry.Profile memory p = pr.getProfile(user);
+        assertEq(p.githubUsername, "user123");
+        assertEq(p.techStack.length, 2);
+        assertEq(uint(p.role), uint(ProfileRegistry.Role.Contributor));
+
+        // Update profile
+        string[] memory tech2 = new string[](1);
+        tech2[0] = "Rust";
+        string[] memory topics2 = new string[](2);
+        topics2[0] = "AI";
+        topics2[1] = "Infra";
+
+        vm.prank(user);
+        pr.updateProfile(
+            "I also do Rust",
+            tech2,
+            topics2,
+            ProfileRegistry.ExperienceLevel.Advanced,
+            ProfileRegistry.Role.Both
+        );
+
+        p = pr.getProfile(user);
+        assertEq(p.techStack.length, 1);
+        assertEq(p.topics.length, 2);
+        assertEq(uint(p.experience), uint(ProfileRegistry.ExperienceLevel.Advanced));
+        assertEq(uint(p.role), uint(ProfileRegistry.Role.Both));
+    }
+
+    function testReputationUpdateRole() public {
+        // Grant updater role to this test contract
+        bytes32 role = pr.REPUTATION_UPDATER_ROLE();
+        pr.grantRole(role, address(this));
+
+        string[] memory tech = new string[](1);
+        tech[0] = "Solidity";
+        string[] memory topics = new string[](0);
+
+        vm.prank(user);
+        pr.createProfile("u", "b", tech, topics, ProfileRegistry.ExperienceLevel.Beginner, ProfileRegistry.Role.Contributor);
+
+        pr.recordIssueCompletion(user, 100 ether);
+        ProfileRegistry.Profile memory p = pr.getProfile(user);
+        // 10 points per issue + 1 per 0.01 ETH => 10 + 100 ether / 0.01 ether = 10 + 10000 = 10010
+        assertEq(p.reputationScore, 10010);
+        assertEq(p.completedIssues, 1);
+        assertEq(p.totalEarned, 100 ether);
+    }
+}

--- a/base-oss-app/contracts/test/RepoRegistry.t.sol
+++ b/base-oss-app/contracts/test/RepoRegistry.t.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import {RepoRegistry} from "../src/RepoRegistry.sol";
+
+contract RepoRegistryTest is Test {
+    RepoRegistry rr;
+    address maint = address(0xA11CE);
+    address contrib = address(0xB0B);
+
+    function setUp() public {
+        rr = new RepoRegistry();
+        vm.label(maint, "maint");
+        vm.label(contrib, "contrib");
+    }
+
+    function _addRepo() internal returns (uint256) {
+        string[] memory tech = new string[](1);
+        tech[0] = "Solidity";
+        string[] memory topics = new string[](1);
+        topics[0] = "Infra";
+        vm.prank(maint);
+        return rr.addRepo("owner/repo", "repo", "desc", tech, topics, "", 0);
+    }
+
+    function testAddUpdateDeactivateReactivateRepo() public {
+        uint256 repoId = _addRepo();
+        // update
+        string[] memory tech2 = new string[](1);
+        tech2[0] = "Rust";
+        string[] memory topics2 = new string[](0);
+        vm.prank(maint);
+        rr.updateRepo(repoId, "newdesc", tech2, topics2, "https://example", 10);
+        RepoRegistry.Repo memory r = rr.getRepo(repoId);
+        assertEq(r.stars, 10);
+        // deactivate
+        vm.prank(maint);
+        rr.deactivateRepo(repoId);
+        r = rr.getRepo(repoId);
+        assertFalse(r.isActive);
+        // reactivate
+        vm.prank(maint);
+        rr.reactivateRepo(repoId);
+        r = rr.getRepo(repoId);
+        assertTrue(r.isActive);
+    }
+
+    function testIssueLifecycle() public {
+        uint256 repoId = _addRepo();
+        string[] memory labels = new string[](1);
+        labels[0] = "good-first-issue";
+        vm.prank(maint);
+        uint256 issueId = rr.addIssue(
+            repoId,
+            "owner/repo#1",
+            "Fix bug",
+            "desc",
+            labels,
+            RepoRegistry.Difficulty.Beginner,
+            4,
+            0
+        );
+        // assign by maintainer
+        vm.prank(maint);
+        rr.assignIssue(issueId, contrib);
+        // contributor starts
+        vm.prank(contrib);
+        rr.startIssue(issueId);
+        // maintainer completes
+        vm.prank(maint);
+        rr.completeIssue(issueId);
+        // completed issues should include issueId
+        uint256[] memory completed = rr.getIssuesByStatus(RepoRegistry.Status.Completed);
+        assertEq(completed.length, 1);
+        assertEq(completed[0], issueId);
+    }
+}

--- a/base-oss-app/contracts/test/TipJar.t.sol
+++ b/base-oss-app/contracts/test/TipJar.t.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import {TipJar} from "../src/TipJar.sol";
+import {ProfileRegistry} from "../src/ProfileRegistry.sol";
+import {RepoRegistry} from "../src/RepoRegistry.sol";
+
+contract TipJarTest is Test {
+    ProfileRegistry pr;
+    RepoRegistry rr;
+    TipJar tj;
+
+    address maint = address(0xA11CE);
+    address contrib = address(0xB0B);
+    address tipper = address(0xCAFE);
+
+    function setUp() public {
+        pr = new ProfileRegistry();
+        rr = new RepoRegistry();
+        tj = new TipJar(address(pr), address(rr), address(this));
+
+        // Grant TJ as reputation updater
+        pr.grantRole(pr.REPUTATION_UPDATER_ROLE(), address(tj));
+
+        // Create contributor profile
+        string[] memory tech = new string[](1);
+        tech[0] = "Solidity";
+        string[] memory topics = new string[](0);
+        vm.prank(contrib);
+        pr.createProfile("b0b", "", tech, topics, ProfileRegistry.ExperienceLevel.Beginner, ProfileRegistry.Role.Contributor);
+
+        // Add repo + issue
+        string[] memory rtech = new string[](0);
+        string[] memory rtopics = new string[](0);
+        vm.prank(maint);
+        uint256 repoId = rr.addRepo("o/r", "r", "d", rtech, rtopics, "", 0);
+        string[] memory labels = new string[](0);
+        vm.prank(maint);
+        rr.addIssue(repoId, "o/r#1", "task", "d", labels, RepoRegistry.Difficulty.Beginner, 1, 0);
+    }
+
+    function testTipContributorUpdatesAccounting() public {
+        // Set minTipAmount small for test
+        vm.prank(address(this));
+        tj.updateMinTipAmount(0.0001 ether);
+
+        // Fund tipper
+        vm.deal(tipper, 1 ether);
+
+        uint256 startContribBal = contrib.balance;
+        // tip with issueId 1
+        vm.prank(tipper);
+        tj.tipContributor{value: 0.5 ether}(contrib, 1, "nice work");
+
+        // Receive funds
+        assertEq(contrib.balance, startContribBal + 0.5 ether);
+        // Totals reflect
+        assertEq(tj.totalTipsReceived(contrib), 0.5 ether);
+        assertEq(tj.totalTipsSent(tipper), 0.5 ether);
+        assertEq(tj.totalTipsCount(), 1);
+
+        // Reputation updated
+        ProfileRegistry.Profile memory p = pr.getProfile(contrib);
+        assertGt(p.reputationScore, 0);
+        assertEq(p.totalEarned, 0.5 ether);
+    }
+}


### PR DESCRIPTION
Add comprehensive Foundry tests for core contracts.

- Covers ProfileRegistry, RepoRegistry, ApplicationManager, TipJar
- Validates repo + issue lifecycle, applications, tipping + reputation
- Adds CI workflow to run forge tests on PRs

How to verify locally:
```
cd base-oss-app/contracts
forge test --match-path 'test/*' -vv
```
